### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-build-publish-release.yml
+++ b/.github/workflows/docker-build-publish-release.yml
@@ -25,7 +25,7 @@ jobs:
       shell: bash
       run: echo "RELEASE_VERSION="$(git describe --tags --abbrev=0 ${GITHUB_SHA}) >> $GITHUB_ENV
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         GIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
         GIT_REVISION: ${{ steps.extract_hash.outputs.hash }}

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -24,7 +24,7 @@ jobs:
       shell: bash
       run: echo "RELEASE_VERSION="$(git describe --tags --abbrev=0 ${GITHUB_SHA}) >> $GITHUB_ENV
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         GIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
         GIT_REVISION: ${{ steps.extract_hash.outputs.hash }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore